### PR TITLE
Fix unmarshal bug when SecretString values is not string value

### DIFF
--- a/envinjector/secrets_manager.go
+++ b/envinjector/secrets_manager.go
@@ -2,6 +2,7 @@ package envinjector
 
 import (
 	"encoding/json"
+	"fmt"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/secretsmanager"
 	"os"
@@ -17,7 +18,7 @@ func injectEnvironSecretManager(name string, decorator envKeyDecorator) {
 	if err != nil {
 		logger.Fatalf("secretsmanager:GetSecretValue failed. (name: %s)\n %v", name, err)
 	}
-	secrets := make(map[string]string)
+	secrets := make(map[string]interface{})
 	err = json.Unmarshal([]byte(aws.StringValue(ret.SecretString)), &secrets)
 	if err != nil {
 		logger.Fatalf("secretsmanager:GetSecretValue returns invalid json. (name: %s)\n %v", name, err)
@@ -25,7 +26,7 @@ func injectEnvironSecretManager(name string, decorator envKeyDecorator) {
 	for key, val := range secrets {
 		key = decorator.decorate(key)
 		if os.Getenv(key) == "" {
-			os.Setenv(key, val)
+			os.Setenv(key, fmt.Sprintf("%v", val))
 			tracef("env injected: %s", key)
 		}
 	}


### PR DESCRIPTION
On AWS Secrets Manager, SecretString response contains number value.
For example, if we use RDS secrets, port value is number.  
On current implementation, `secrets` variable is map to string, so unmarshall is failed when using RDS secrets.
This PullRequest solve them to modify `secrets` type to map to interface.